### PR TITLE
Changed  '-' to '.-' in barcode function to prevent number-matrix sub…

### DIFF
--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -5100,7 +5100,7 @@ function barcode(D::Dict;dim = 1,ocf = false)
 		bc[finran] 			= 	D["ocg2rad"][bcc[finran]]
 		bc[evergrran,2]    .= 	Inf
 	else
-		bc 					= 	length(D["ocg2rad"])-bc
+		bc 					= 	length(D["ocg2rad"]).-bc
 	end
 
 	return bc

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4545,6 +4545,7 @@ function getbetticurve(D::Dict,sd;ocf = false)
 			ran = .+ (bco[i,1]:(bco[i,2]-1))
 			v[ran]+=1
 		catch e
+			println(v[ran])
 			println(bco[i,1]:(bco[i,2]-1))
 			error(e)
 		end

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -5100,7 +5100,7 @@ function barcode(D::Dict;dim = 1,ocf = false)
 		bc[finran] 			= 	D["ocg2rad"][bcc[finran]]
 		bc[evergrran,2]    .= 	Inf
 	else
-		bc 					= 	length(D["ocg2rad"]).-bc
+		bc 					= 	length(D["ocg2rad"])-bc
 	end
 
 	return bc

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4547,6 +4547,7 @@ function getbetticurve(D::Dict,sd;ocf = false)
 		catch e
 			println(bco[i,1]:(bco[i,2]-1))
 			error(e)
+		end
 	end
 
 	if ocf == false

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4541,7 +4541,7 @@ function getbetticurve(D::Dict,sd;ocf = false)
 	bco = convert(Array{Int64},bco)
 
 	for i = 1:size(bco,1)
-		ran = 1+ (bco[i,1]:(bco[i,2]-1))
+		ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
 		v[ran]+=1
 	end
 

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -5106,7 +5106,7 @@ function barcode(D::Dict;dim = 1,ocf = false)
 		bc[finran] 			= 	D["ocg2rad"][bcc[finran]]
 		bc[evergrran,2]    .= 	Inf
 	else
-		bc 					= 	length(D["ocg2rad"])-bc
+		bc 					= 	length(D["ocg2rad"]).-bc
 	end
 
 	return bc

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4542,7 +4542,7 @@ function getbetticurve(D::Dict,sd;ocf = false)
 
 	for i = 1:size(bco,1)
 		try
-			ran = .+ (bco[i,1]:(bco[i,2]-1))
+			ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
 			v[ran]+=1
 		catch e
 			println(v[ran])

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4543,7 +4543,7 @@ function getbetticurve(D::Dict,sd;ocf = false)
 	for i = 1:size(bco,1)
 		#try
 		ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
-		v[ran]+=1
+		v[ran] = v[ran] .+ 1
 		#catch e
 		#	println(v[ran])
 		#	println(bco[i,1]:(bco[i,2]-1))

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4541,8 +4541,12 @@ function getbetticurve(D::Dict,sd;ocf = false)
 	bco = convert(Array{Int64},bco)
 
 	for i = 1:size(bco,1)
-		ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
-		v[ran]+=1
+		try
+			ran = .+ (bco[i,1]:(bco[i,2]-1))
+			v[ran]+=1
+		catch e
+			println(bco[i,1]:(bco[i,2]-1))
+			error(e)
 	end
 
 	if ocf == false

--- a/src/Eirene.jl
+++ b/src/Eirene.jl
@@ -4541,14 +4541,14 @@ function getbetticurve(D::Dict,sd;ocf = false)
 	bco = convert(Array{Int64},bco)
 
 	for i = 1:size(bco,1)
-		try
-			ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
-			v[ran]+=1
-		catch e
-			println(v[ran])
-			println(bco[i,1]:(bco[i,2]-1))
-			error(e)
-		end
+		#try
+		ran = 1 .+ (bco[i,1]:(bco[i,2]-1))
+		v[ran]+=1
+		#catch e
+		#	println(v[ran])
+		#	println(bco[i,1]:(bco[i,2]-1))
+		#	error(e)
+		#end
 	end
 
 	if ocf == false


### PR DESCRIPTION
…traction type error.

This bugfix was suggested by [Philip Egger](https://github.com/pegger0709) [here.](https://github.com/Eetion/Eirene.jl/issues/5)